### PR TITLE
Fix version and add `--version` to CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
-on: pull_request
+on:
+  - pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/src/crdb/__init__.py
+++ b/src/crdb/__init__.py
@@ -1,4 +1,6 @@
-__version__ = '0.0.0'
+from importlib.metadata import version
+
+__version__ = version("crdb")
 
 from ._lib import (
     query,
@@ -11,6 +13,7 @@ from ._lib import (
 
 
 __all__ = [
+    "__version__",
     "VALID_NAMES",
     "query",
     "clear_cache",

--- a/src/crdb/cli.py
+++ b/src/crdb/cli.py
@@ -38,9 +38,9 @@ def main(args=None):
         help="Timeout for server request in seconds. Default is 120.",
     )
     parser.add_argument(
-        "-v,--version",
+        "--version",
         action="version",
-        version=f"%(prog)s {crdb.__version__}",
+        version=f"crdb-{crdb.__version__}",
         help="Print version of crdb Python library.",
     )
 

--- a/src/crdb/cli.py
+++ b/src/crdb/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import crdb
 from crdb._lib import _url, _server_request, query
 import inspect
 import re
@@ -30,7 +31,18 @@ def main(args=None):
         else:
             parser.add_argument(f"--{name2}", type=tp, default=par.default, help=h)
 
-    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Timeout for server request in seconds. Default is 120.",
+    )
+    parser.add_argument(
+        "-v,--version",
+        action="version",
+        version=f"%(prog)s {crdb.__version__}",
+        help="Print version of crdb Python library.",
+    )
 
     args = parser.parse_args(args=args)
     kwargs = {k.replace("-", "_"): v for (k, v) in vars(args).items() if k != "timeout"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,3 +3,7 @@ from crdb.cli import main
 
 def test_main():
     main(["B/C"])
+
+
+def test_version():
+    main(["-v"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 from crdb.cli import main
+import crdb
+import re
 
 
 def test_main():
@@ -6,4 +8,11 @@ def test_main():
 
 
 def test_version(capsys):
-    main(["-v"])
+    try:
+        main(["--version"])
+    except SystemExit:
+        pass
+    c = capsys.readouterr()
+    m = re.match(r"crdb-([0-9]+\.[0-9]+\.[0-9]+)", c.out)
+    assert m
+    assert m.group(1) == crdb.__version__

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,5 +5,5 @@ def test_main():
     main(["B/C"])
 
 
-def test_version():
+def test_version(capsys):
     main(["-v"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 from crdb.cli import main
 import crdb
-import re
 
 
 def test_main():
@@ -13,6 +12,4 @@ def test_version(capsys):
     except SystemExit:
         pass
     c = capsys.readouterr()
-    m = re.match(r"crdb-([0-9]+\.[0-9]+\.[0-9]+)", c.out)
-    assert m
-    assert m.group(1) == crdb.__version__
+    assert c.out == f"crdb-{crdb.__version__}\n"


### PR DESCRIPTION
* `crdb.__version__` used to display 0.0.0, regardless of the actual version.
* Added `--version` option to command-line interface.