### PR TITLE
add crdb.all

### DIFF
--- a/src/crdb/__init__.py
+++ b/src/crdb/__init__.py
@@ -9,6 +9,7 @@ from ._lib import (
     VALID_NAMES,
     reference_urls,
     bibliography,
+    all,
 )
 
 
@@ -20,4 +21,5 @@ __all__ = [
     "experiment_masks",
     "reference_urls",
     "bibliography",
+    "all",
 ]

--- a/src/crdb/_lib.py
+++ b/src/crdb/_lib.py
@@ -479,8 +479,14 @@ def _url(
     if flux_rescaling < 0 or flux_rescaling > 2.5:
         raise ValueError(f"invalid flux_rescaling {flux_rescaling}")
 
+    if time_series and time_series not in ("no", "only", "all"):
+        raise ValueError(f"invalid time_series {time_series}")
+
     if format and format not in ("usine", "galprop", "csv"):
         raise ValueError(f"invalid format {format}")
+
+    if modulation and modulation not in ("USO05", "USO17", "GHE17"):
+        raise ValueError(f"invalid modulation {modulation}")
 
     # do the query
     kwargs = {

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,0 +1,9 @@
+from crdb import all
+import pytest
+
+
+@pytest.mark.parametrize("quantity", ("B/C", "H", "Li"))
+def test_all(quantity):
+    tab = all()
+    mask = tab["quantity"] == quantity
+    assert len(tab[mask]) > 1


### PR DESCRIPTION
- New command `crdb.all` downloads the full data base in raw form. No conversions are performed.
- `format` argument was removed from `crdb.query`, which makes no sense since the output format is a numpy array anyway.
- Validation added for several arguments of `crdb._lib._url`