### PR TITLE
Switch to csv-asimport

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.py }} ${{ matrix.os }} ${{ matrix.arch }}
+    name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.python_arch }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -20,7 +20,7 @@ jobs:
           # - python: 'pypy-3.8'
           #   python_arch: 'x64'
           #   os: 'ubuntu-latest'
-          - python: '3.9'
+          - python: '3.8'
             python_arch: 'x64'
             os: 'windows-latest'
           - python: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,26 +9,26 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.python_arch }}
+    name: ${{ matrix.python }} ${{ matrix.os }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Broken for some reason not related to us
-          # - python: 'pypy-3.8'
-          #   python_arch: 'x64'
-          #   os: 'ubuntu-latest'
           - python: '3.8'
-            python_arch: 'x64'
+            arch: 'x64'
             os: 'windows-latest'
           - python: '3.10'
-            python_arch: 'x64'
+            arch: 'x64'
             os: 'macos-latest'
           - python: '3.11'
-            python_arch: 'x64'
+            arch: 'x64'
             os: 'ubuntu-latest'
+        # Broken for some reason not related to us
+        # - python: 'pypy-3.8'
+        #   arch: 'x64'
+        #   os: 'ubuntu-latest'
     steps:
     - uses: actions/checkout@v3
       with:
@@ -40,6 +40,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-        architecture: ${{ matrix.python_arch }}
+        architecture: ${{ matrix.arch }}
     - run: python -m pip install --progress-bar=off --prefer-binary -e .[test]
     - run: python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cachier
+        key: ${{ runner.os }}-cachier
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}

--- a/src/crdb/_lib.py
+++ b/src/crdb/_lib.py
@@ -332,6 +332,47 @@ COMBINE = (
     "Voyager",
 )
 
+_CSV_FIELDS = (
+    ("quantity", "U32"),  # DATA-QTY
+    ("sub_exp", "U100"),  # SUBEXP-NAME
+    ("e_type", "U4"),  # DATA-EAXIS
+    ("e", "f8"),  # DATA-E_MEAN
+    ("e_bin", "f8", (2,)),  # EBIN_LOW, EBIN_HIGH
+    ("value", "f8"),  # QUANTITY VALUE
+    ("err_sta", "f8", (2,)),  # ERR_STAT-,  ERR_STAT+
+    ("err_sys", "f8", (2,)),  # ERR_SYST-, ERR_SYST+
+    ("ads", "U32"),  # ADS URL FOR PAPER REF
+    ("phi", "f8"),  # phi [MV]
+    ("distance", "f8"),  # DISTANCE [AU]
+    ("datetime", "U256"),  # DATIMES
+    ("is_upper_limit", "?"),  # IS UPPER LIMIT
+)
+
+# fields set to None here are skipped during parsing
+_CSV_ASIMPORT_FIELDS = (
+    ("exp", "U64"),  # EXP-NAME
+    ("exp_type", "U16"),  # EXP-TYPE
+    None,  # EXP-HTML
+    None,  # EXP-STARTYEAR
+    ("sub_exp", "U100"),  # SUBEXP-NAME
+    None,  # SUBEXP-DESCRIPTION
+    ("e_relerr", "f8"),  # SUBEXP-ESCALE_RELERR
+    None,  # SUBEXP-INFO
+    ("distance", "f8"),  # SUBEXP-DISTANCE
+    ("datetime", "U256"),  # SUBEXP-DATES
+    ("ads", "U32"),  # PUBLI-HTML
+    None,  # PUBLI-DATAORIGIN
+    ("quantity", "U32"),  # DATA-QTY
+    ("e_type", "U4"),  # DATA-EAXIS
+    ("e", "f8"),  # DATA-E_MEAN
+    ("e_bin", "f8", (2,)),  # DATA-E_BIN_L, DATA-E_BIN_U
+    ("value", "f8"),  # DATA-VAL
+    ("err_sta", "f8", (2,)),  # DATA-VAL_ERRSTAT_L, DATA-VAL_ERRSTAT_U
+    ("err_sys", "f8", (2,)),  # DATA-VAL_ERRSYST_L, DATA-VAL_ERRSYST_U
+    ("is_upper_limit", "?"),  # DATA-ISUPPERLIM
+    ("phi", "f8"),  # phi [MV]
+)
+
 
 def query(
     quantity: Union[str, Sequence[str]],
@@ -474,7 +515,7 @@ def query(
     if len(data) == 1:
         raise ValueError(data[0])
 
-    table = _convert(data)
+    table = _convert_csv(data, _CSV_ASIMPORT_FIELDS)
 
     return table
 
@@ -595,109 +636,8 @@ def _server_request(url: str, timeout: int) -> List[str]:
     return data
 
 
-def _convert(data: List[str]) -> NDArray:
+def _convert_csv(data: List[str], fields) -> NDArray:
     # convert text to numpy record array
-
-    # Use this for csv-asimport or csv-extended when it becomes available
-    # fields set to None here are skipped during parsing
-    fields = [
-        ("exp", "U64"),  # EXP-NAME
-        ("exp_type", "U16"),  # EXP-TYPE
-        None,  # EXP-HTML
-        None,  # EXP-STARTYEAR
-        ("sub_exp", "U100"),  # SUBEXP-NAME
-        None,  # SUBEXP-DESCRIPTION
-        ("e_relerr", "f8"),  # SUBEXP-ESCALE_RELERR
-        None,  # SUBEXP-INFO
-        ("distance", "f8"),  # SUBEXP-DISTANCE
-        ("datetime", "U256"),  # SUBEXP-DATES
-        ("ads", "U32"),  # PUBLI-HTML
-        None,  # PUBLI-DATAORIGIN
-        ("quantity", "U32"),  # DATA-QTY
-        ("e_type", "U4"),  # DATA-EAXIS
-        ("e", "f8"),  # DATA-E_MEAN
-        ("e_bin", "f8", (2,)),  # DATA-E_BIN_L, DATA-E_BIN_U
-        ("value", "f8"),  # DATA-VAL
-        ("err_sta", "f8", (2,)),  # DATA-VAL_ERRSTAT_L, DATA-VAL_ERRSTAT_U
-        ("err_sys", "f8", (2,)),  # DATA-VAL_ERRSYST_L, DATA-VAL_ERRSYST_U
-        ("is_upper_limit", "?"),  # DATA-ISUPPERLIM
-        ("phi", "f8"),  # phi [MV]
-    ]
-
-    mapping = []
-    for f in fields:
-        if f is None:
-            mapping.append(None)
-        elif len(f) == 3:
-            for k in range(f[2][0]):
-                mapping.append((f[0], k))
-        else:
-            mapping.append(f[0])
-    fields = [x for x in fields if x is not None]
-
-    for start, line in enumerate(data):
-        if not line.startswith("#"):
-            break
-
-    table = np.recarray(len(data) - start - 1, fields)
-    for idx, row in enumerate(csv.reader(data[start:-1])):
-        for val, key in zip(row, mapping):
-            if key is None:
-                continue
-            if isinstance(key, tuple):
-                key, pos = key
-                table[idx][key][pos] = val
-            else:
-                if key == "is_upper_limit":
-                    val = int(val)
-                table[idx][key] = val
-
-    # workaround: replace &amp; in sub_exp strings
-    sub_exps = np.unique(table["sub_exp"])
-    code = "&amp;"
-    for sub_exp in sub_exps:
-        if code not in sub_exp:
-            continue
-        mask = table["sub_exp"] == sub_exp
-        table["sub_exp"][mask] = sub_exp.replace(code, "&")
-
-    # workaround: err_stat_minus or err_sys_minus may be negative
-    for x in ("sta", "sys"):
-        field = f"err_{x}"
-        table[field] = np.abs(table[field])
-
-    return table
-
-
-def _convert_csv(data: List[str]) -> NDArray:
-    # convert text to numpy record array
-
-    # Use this for csv-asimport or csv-extended when it becomes available
-    # fields set to None here are skipped during parsing
-    fields = [
-        ("exp", "U64"),  # EXP-NAME
-        ("exp_type", "U16"),  # EXP-TYPE
-        None,  # EXP-HTML
-        None,  # EXP-STARTYEAR
-        ("sub_exp", "U100"),  # SUBEXP-NAME
-        None,  # SUBEXP-DESCRIPTION
-        ("e_relerr", "f8"),  # SUBEXP-ESCALE_RELERR
-        None,  # SUBEXP-INFO
-        ("distance", "f8"),  # SUBEXP-DISTANCE
-        ("datetime", "U256"),  # SUBEXP-DATES
-        ("ads", "U32"),  # PUBLI-HTML
-        None,  # PUBLI-DATAORIGIN
-        ("quantity", "U32"),  # DATA-QTY
-        ("e_type", "U4"),  # DATA-EAXIS
-        ("e", "f8"),  # DATA-E_MEAN
-        ("e_bin", "f8", (2,)),  # DATA-E_BIN_L, DATA-E_BIN_U
-        ("value", "f8"),  # DATA-VAL
-        ("err_sta", "f8", (2,)),  # DATA-VAL_ERRSTAT_L, DATA-VAL_ERRSTAT_U
-        ("err_sys", "f8", (2,)),  # DATA-VAL_ERRSYST_L, DATA-VAL_ERRSYST_U
-        ("is_upper_limit", "?"),  # DATA-ISUPPERLIM
-        ("phi", "f8"),  # phi [MV]
-    ]
-
     mapping = []
     for f in fields:
         if f is None:
@@ -871,7 +811,7 @@ def all() -> NDArray:
     Return the full raw CRDB database as a table.
     """
     data = _all_request()
-    return _convert_csv(data)
+    return _convert_csv(data, _CSV_FIELDS)
 
 
 def solar_system_composition() -> Dict[str, List[Tuple[int, float]]]:


### PR DESCRIPTION
The csv-asimport format provides more useful information. For now, it is only supported in `crdb.query`, while `crdb.all` still uses the more limited `csv` format. The tables returned by `crdb.all` therefore contain fewer columns.

Internally, we now use the csv package from Python to parse the input, which became possible after the csv-asimport format was fixed on the server. This should speed up the parsing considerably compared to the internal workaround code that was used before.